### PR TITLE
Added mkdocs into the command to deploy the docs

### DIFF
--- a/08-docs/README.md
+++ b/08-docs/README.md
@@ -161,7 +161,7 @@ remember anything:
   docs-publish:
     desc: Publish the documentation to gh-pages
     cmds:
-      - poetry run gh-deploy --force
+      - poetry run mkdocs gh-deploy --force
 ```
 
 Now add another step after publishing your package to the


### PR DESCRIPTION
Hey man,

was playing around with the docs and found out that the mkdocs command was missing, or could that be a windows thing? Wdyt?